### PR TITLE
Add mix_env choosing when making release

### DIFF
--- a/lib/mix/tasks/alpine_release.ex
+++ b/lib/mix/tasks/alpine_release.ex
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.Alpine.Release do
 
     execute "rm -rf rel"
     execute "(docker stop builder && docker rm builder) || true"
-    execute "docker run --name builder -e MIX_ENV=prod -w /release -di renderedtext/elixir-thrift-dev"
+    execute "docker run --name builder -e MIX_ENV=#{System.get_env("MIX_ENV") || "prod"} -w /release -di renderedtext/elixir-thrift-dev"
     execute "docker cp . builder:/release"
     execute "docker exec -i builder sh -c 'apk add erlang-edoc'"
     execute "docker exec -i builder sh -c 'apk add erlang-snmp'"


### PR DESCRIPTION
Option to choose mix_env when releasing your app, because before your
release was always made with prod configuration.